### PR TITLE
Add README to the project's metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup
+from pathlib import Path
+
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 exec(open('./src/WireMockLibrary/version.py').read())
 
@@ -7,6 +11,8 @@ setup(name='robotframework-wiremock',
       package_dir={'': 'src'},
       version=VERSION,
       description='Robot framework library for WireMock',
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       author='Timo Yrjola',
       author_email='timo.yrjola@gmail.com',
       url='https://github.com/tyrjola/robotframework-wiremock',


### PR DESCRIPTION
Fixes #12 
Added **long_description** and **long_description_content_type** fields to setup.py.
I had to introduce logic in order to read the contents of the README.md file, 

## References
[Documentation](https://packaging.python.org/en/latest/guides/making-a-pypi-friendly-readme/)

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)