### PR TITLE
Overall Reset Of Server, both mappings and requests.

### DIFF
--- a/src/WireMockLibrary/library.py
+++ b/src/WireMockLibrary/library.py
@@ -219,6 +219,11 @@ class WireMockLibrary(object):
         """Resets all logged requests on the wiremock server.
         """
         self._send_request("/__admin/requests/reset")
+    
+    def reset_server(self):
+        """Resets the wiremock server, including all mappings and request logs.
+        """
+        self._send_request("/__admin/reset")
 
     def _send_request(self, path, data=None):
         if isinstance(data, dict):


### PR DESCRIPTION
I noticed that this library didn't had an update in a while.
The "/__admin/requests/reset" seems to be doing nothing on the wiremock 3.13 and the wiremock-ui 3.13.
However the overall reset "/__admin/reset" does reset both mappings and requests. So I thought it would be nice to add this call to the library

## References

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
